### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Java Test with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Coderic/org.coderic.bank.gateway/security/code-scanning/2](https://github.com/Coderic/org.coderic.bank.gateway/security/code-scanning/2)

The best way to fix the problem is to explicitly add a `permissions` block that follows the principle of least privilege—granting only the minimal required permissions, which is typically `contents: read` for workflows that only check out code and run tests, as in this example. This block can be added either at the root level of the workflow (applies to all jobs) or at the job level (applies only to the specific job). Since this workflow only contains a single job (`test`), and there are no indications future jobs will require different permissions, we can add the `permissions` block at the root for maximally clear and maintainable configuration. The addition should be placed after the `name` key but before `on:` to conform to YAML structure conventions.

No additional imports, methods, or definitions are required; only YAML configuration changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
